### PR TITLE
keep smaller sha builds in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,3 @@
 build
 test
 src/sha_dev.js
-src/sha1.js
-src/sha256.js
-src/sha512.js


### PR DESCRIPTION
It would be great to keep these in for npm since it is fairly common to use npm for browser side code if you are using a system like browserify or webpack to pack your client side code.

If you include these files then I could do `var sha = require('jssha/src/sha256')` and get a slightly smaller Webpack build :-)

If you decide to merge this PR please npm publish a new version.
