### PR TITLE
Fixes ERR_PACKAGE_PATH_NOT_EXPORTED issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "./sha1": "./dist/sha1.js",
     "./sha256": "./dist/sha256.js",
     "./sha512": "./dist/sha512.js",
-    "./sha3": "./dist/sha3.js"
+    "./sha3": "./dist/sha3.js",
+    "./dist/sha1": "./dist/sha1.js",
+    "./dist/sha256": "./dist/sha256.js",
+    "./dist/sha512": "./dist/sha512.js",
+    "./dist/sha3": "./dist/sha3.js"
+    
   },
   "module": "./dist/sha.mjs",
   "types": "./dist/sha.d.ts",


### PR DESCRIPTION
Adding exports to package.json to enable ====> const jsSHA = require("jssha/dist/sha256");

ERR_PACKAGE_PATH_NOT_EXPORTED does not occur in the following node and npm versions
Node: v12.13.1
npm: 6.12.1


ERR_PACKAGE_PATH_NOT_EXPORTED occurs in the following node and npm versions
Node: v12.18.2
npm: 6.14.5
Error:
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/sha256' is not defined by "exports" in /Programs/Project/node_modules/jssha/package.json
at applyExports (internal/modules/cjs/loader.js:491:9)
    at resolveExports (internal/modules/cjs/loader.js:507:23)
    at Function.Module._findPath (internal/modules/cjs/loader.js:635:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:953:27)
    at Function.Module._load (internal/modules/cjs/loader.js:842:27)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (internal/modules/cjs/helpers.js:72:18)
   .
   .
   .

This got resolved by adding the following in package.json exports
"./dist/sha1": "./dist/sha1.js",
"./dist/sha256": "./dist/sha256.js",
"./dist/sha512": "./dist/sha512.js",
"./dist/sha3": "./dist/sha3.js"