### PR TITLE
emit *.d.mts type files for esm entries

### DIFF
--- a/dist/sha.d.mts
+++ b/dist/sha.d.mts
@@ -1,0 +1,152 @@
+declare type EncodingType = "UTF8" | "UTF16BE" | "UTF16LE";
+declare type FormatNoTextType = "HEX" | "B64" | "BYTES" | "ARRAYBUFFER" | "UINT8ARRAY";
+declare type GenericInputType = {
+    value: string;
+    format: "TEXT";
+    encoding?: EncodingType;
+} | {
+    value: string;
+    format: "B64" | "HEX" | "BYTES";
+} | {
+    value: ArrayBuffer;
+    format: "ARRAYBUFFER";
+} | {
+    value: Uint8Array;
+    format: "UINT8ARRAY";
+};
+declare type FixedLengthOptionsNoEncodingType = {
+    hmacKey?: GenericInputType;
+} | {
+    numRounds?: number;
+};
+declare type FixedLengthOptionsEncodingType = {
+    hmacKey?: GenericInputType;
+    encoding?: EncodingType;
+} | {
+    numRounds?: number;
+    encoding?: EncodingType;
+};
+interface SHAKEOptionsNoEncodingType {
+    numRounds?: number;
+}
+interface SHAKEOptionsEncodingType extends SHAKEOptionsNoEncodingType {
+    encoding?: EncodingType;
+}
+interface CSHAKEOptionsNoEncodingType {
+    customization?: GenericInputType;
+    funcName?: GenericInputType;
+}
+interface CSHAKEOptionsEncodingType extends CSHAKEOptionsNoEncodingType {
+    encoding?: EncodingType;
+}
+interface KMACOptionsNoEncodingType {
+    kmacKey: GenericInputType;
+    customization?: GenericInputType;
+}
+interface KMACOptionsEncodingType extends KMACOptionsNoEncodingType {
+    encoding?: EncodingType;
+}
+
+declare type FixedLengthVariantType = "SHA-1" | "SHA-224" | "SHA-256" | "SHA-384" | "SHA-512" | "SHA3-224" | "SHA3-256" | "SHA3-384" | "SHA3-512";
+declare class jsSHA {
+    private readonly shaObj;
+    /**
+     * @param variant The desired SHA variant (SHA-1, SHA-224, SHA-256, SHA-384, SHA-512, SHA3-224, SHA3-256, SHA3-256,
+     *   SHA3-384, SHA3-512, SHAKE128, SHAKE256, CSHAKE128, CSHAKE256, KMAC128, or KMAC256) as a string.
+     * @param inputFormat The input format to be used in future `update` calls (TEXT, HEX, B64, BYTES, ARRAYBUFFER,
+     *   or UINT8ARRAY) as a string.
+     * @param options Options in the form of { encoding?: "UTF8" | "UTF16BE" | "UTF16LE"; numRounds?: number }.
+     *   `encoding` is for only TEXT input (defaults to UTF8) and `numRounds` defaults to 1.
+     *   `numRounds` is not valid for any of the MAC or CSHAKE variants.
+     *   * If the variant supports HMAC, `options` may have an additional `hmacKey` key which must be in the form of
+     *     {value: <INPUT>, format: <FORMAT>, encoding?: "UTF8" | "UTF16BE" | "UTF16LE"} where <FORMAT> takes the same
+     *     values as `inputFormat` and <INPUT> can be a `string | ArrayBuffer | Uint8Array` depending on <FORMAT>.
+     *     Supplying this key switches to HMAC calculation and replaces the now deprecated call to `setHMACKey`.
+     *   * If the variant is CSHAKE128 or CSHAKE256, `options` may have two additional keys, `customization` and `funcName`,
+     *     which are the NIST customization and function-name strings.  Both must be in the same form as `hmacKey`.
+     *   * If the variant is KMAC128 or KMAC256, `options` can include the `customization` key from CSHAKE variants and
+     *     *must* have a `kmacKey` key that takes the same form as the `customization` key.
+     */
+    constructor(variant: FixedLengthVariantType, inputFormat: "TEXT", options?: FixedLengthOptionsEncodingType);
+    constructor(variant: FixedLengthVariantType, inputFormat: FormatNoTextType, options?: FixedLengthOptionsNoEncodingType);
+    constructor(variant: "SHAKE128" | "SHAKE256", inputFormat: "TEXT", options?: SHAKEOptionsEncodingType);
+    constructor(variant: "SHAKE128" | "SHAKE256", inputFormat: FormatNoTextType, options?: SHAKEOptionsNoEncodingType);
+    constructor(variant: "CSHAKE128" | "CSHAKE256", inputFormat: "TEXT", options?: CSHAKEOptionsEncodingType);
+    constructor(variant: "CSHAKE128" | "CSHAKE256", inputFormat: FormatNoTextType, options?: CSHAKEOptionsNoEncodingType);
+    constructor(variant: "KMAC128" | "KMAC256", inputFormat: "TEXT", options: KMACOptionsEncodingType);
+    constructor(variant: "KMAC128" | "KMAC256", inputFormat: FormatNoTextType, options: KMACOptionsNoEncodingType);
+    /**
+     * Takes `input` and hashes as many blocks as possible. Stores the rest for either a future `update` or `getHash` call.
+     *
+     * @param input The input to be hashed.
+     * @returns A reference to the object.
+     */
+    update(input: string | ArrayBuffer | Uint8Array): this;
+    /**
+     * Returns the desired SHA or MAC (if a HMAC/KMAC key was specified) hash of the input fed in via `update` calls.
+     *
+     * @param format The desired output formatting (B64, HEX, BYTES, ARRAYBUFFER, or UINT8ARRAY) as a string.
+     * @param options Options in the form of { outputUpper?: boolean; b64Pad?: string; outputLen?: number;  }.
+     *   `outputLen` is required for variable length output variants (this option was previously called `shakeLen` which
+     *    is now deprecated).
+     *   `outputUpper` is only for HEX output (defaults to false) and b64pad is only for B64 output (defaults to "=").
+     * @returns The hash in the format specified.
+     */
+    getHash(format: "HEX", options?: {
+        outputUpper?: boolean;
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "B64", options?: {
+        b64Pad?: string;
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "BYTES", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "UINT8ARRAY", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): Uint8Array;
+    getHash(format: "ARRAYBUFFER", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): ArrayBuffer;
+    /**
+     * Sets the HMAC key for an eventual `getHMAC` call.  Must be called immediately after jsSHA object instantiation.
+     * Now deprecated in favor of setting the `hmacKey` at object instantiation.
+     *
+     * @param key The key used to calculate the HMAC
+     * @param inputFormat The format of key (HEX, TEXT, B64, BYTES, ARRAYBUFFER, or UINT8ARRAY) as a string.
+     * @param options Options in the form of { encoding?: "UTF8" | "UTF16BE" | "UTF16LE }.  `encoding` is only for TEXT
+     *   and defaults to UTF8.
+     */
+    setHMACKey(key: string, inputFormat: "TEXT", options?: {
+        encoding?: EncodingType;
+    }): void;
+    setHMACKey(key: string, inputFormat: "B64" | "HEX" | "BYTES"): void;
+    setHMACKey(key: ArrayBuffer, inputFormat: "ARRAYBUFFER"): void;
+    setHMACKey(key: Uint8Array, inputFormat: "UINT8ARRAY"): void;
+    /**
+     * Returns the the HMAC in the specified format using the key given by a previous `setHMACKey` call. Now deprecated
+     * in favor of just calling `getHash`.
+     *
+     * @param format The desired output formatting (B64, HEX, BYTES, ARRAYBUFFER, or UINT8ARRAY) as a string.
+     * @param options Options in the form of { outputUpper?: boolean; b64Pad?: string }. `outputUpper` is only for HEX
+     *   output (defaults to false) and `b64pad` is only for B64 output (defaults to "=").
+     * @returns The HMAC in the format specified.
+     */
+    getHMAC(format: "HEX", options?: {
+        outputUpper?: boolean;
+    }): string;
+    getHMAC(format: "B64", options?: {
+        b64Pad?: string;
+    }): string;
+    getHMAC(format: "BYTES"): string;
+    getHMAC(format: "UINT8ARRAY"): Uint8Array;
+    getHMAC(format: "ARRAYBUFFER"): ArrayBuffer;
+}
+
+export { jsSHA as default };

--- a/dist/sha1.d.mts
+++ b/dist/sha1.d.mts
@@ -1,0 +1,163 @@
+declare type EncodingType = "UTF8" | "UTF16BE" | "UTF16LE";
+declare type FormatNoTextType = "HEX" | "B64" | "BYTES" | "ARRAYBUFFER" | "UINT8ARRAY";
+declare type FormatType = "TEXT" | FormatNoTextType;
+declare type GenericInputType = {
+    value: string;
+    format: "TEXT";
+    encoding?: EncodingType;
+} | {
+    value: string;
+    format: "B64" | "HEX" | "BYTES";
+} | {
+    value: ArrayBuffer;
+    format: "ARRAYBUFFER";
+} | {
+    value: Uint8Array;
+    format: "UINT8ARRAY";
+};
+declare type FixedLengthOptionsNoEncodingType = {
+    hmacKey?: GenericInputType;
+} | {
+    numRounds?: number;
+};
+declare type FixedLengthOptionsEncodingType = {
+    hmacKey?: GenericInputType;
+    encoding?: EncodingType;
+} | {
+    numRounds?: number;
+    encoding?: EncodingType;
+};
+interface packedValue {
+    value: number[];
+    binLen: number;
+}
+
+declare abstract class jsSHABase<StateT, VariantT> {
+    /**
+     * @param variant The desired SHA variant.
+     * @param inputFormat The input format to be used in future `update` calls.
+     * @param options Hashmap of extra input options.
+     */
+    protected readonly shaVariant: VariantT;
+    protected readonly inputFormat: FormatType;
+    protected readonly utfType: EncodingType;
+    protected readonly numRounds: number;
+    protected abstract intermediateState: StateT;
+    protected keyWithIPad: number[];
+    protected keyWithOPad: number[];
+    protected remainder: number[];
+    protected remainderLen: number;
+    protected updateCalled: boolean;
+    protected processedLen: number;
+    protected macKeySet: boolean;
+    protected abstract readonly variantBlockSize: number;
+    protected abstract readonly bigEndianMod: -1 | 1;
+    protected abstract readonly outputBinLen: number;
+    protected abstract readonly isVariableLen: boolean;
+    protected abstract readonly HMACSupported: boolean;
+    protected abstract readonly converterFunc: (input: any, existingBin: number[], existingBinLen: number) => packedValue;
+    protected abstract readonly roundFunc: (block: number[], H: StateT) => StateT;
+    protected abstract readonly finalizeFunc: (remainder: number[], remainderBinLen: number, processedBinLen: number, H: StateT, outputLen: number) => number[];
+    protected abstract readonly stateCloneFunc: (state: StateT) => StateT;
+    protected abstract readonly newStateFunc: (variant: VariantT) => StateT;
+    protected abstract readonly getMAC: ((options: {
+        outputLen: number;
+    }) => number[]) | null;
+    protected constructor(variant: VariantT, inputFormat: "TEXT", options?: FixedLengthOptionsEncodingType);
+    protected constructor(variant: VariantT, inputFormat: FormatNoTextType, options?: FixedLengthOptionsNoEncodingType);
+    /**
+     * Hashes as many blocks as possible.  Stores the rest for either a future update or getHash call.
+     *
+     * @param srcString The input to be hashed.
+     * @returns A reference to the object.
+     */
+    update(srcString: string | ArrayBuffer | Uint8Array): this;
+    /**
+     * Returns the desired SHA hash of the input fed in via `update` calls.
+     *
+     * @param format The desired output formatting
+     * @param options Hashmap of output formatting options. `outputLen` must be specified for variable length hashes.
+     *   `outputLen` replaces the now deprecated `shakeLen` key.
+     * @returns The hash in the format specified.
+     */
+    getHash(format: "HEX", options?: {
+        outputUpper?: boolean;
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "B64", options?: {
+        b64Pad?: string;
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "BYTES", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "UINT8ARRAY", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): Uint8Array;
+    getHash(format: "ARRAYBUFFER", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): ArrayBuffer;
+    /**
+     * Sets the HMAC key for an eventual `getHMAC` call.  Must be called immediately after jsSHA object instantiation.
+     *
+     * @param key The key used to calculate the HMAC
+     * @param inputFormat The format of key.
+     * @param options Hashmap of extra input options.
+     */
+    setHMACKey(key: string, inputFormat: "TEXT", options?: {
+        encoding?: EncodingType;
+    }): void;
+    setHMACKey(key: string, inputFormat: "B64" | "HEX" | "BYTES"): void;
+    setHMACKey(key: ArrayBuffer, inputFormat: "ARRAYBUFFER"): void;
+    setHMACKey(key: Uint8Array, inputFormat: "UINT8ARRAY"): void;
+    /**
+     * Internal function that sets the MAC key.
+     *
+     * @param key The packed MAC key to use
+     */
+    protected _setHMACKey(key: packedValue): void;
+    /**
+     * Returns the the HMAC in the specified format using the key given by a previous `setHMACKey` call.
+     *
+     * @param format The desired output formatting.
+     * @param options Hashmap of extra outputs options.
+     * @returns The HMAC in the format specified.
+     */
+    getHMAC(format: "HEX", options?: {
+        outputUpper?: boolean;
+    }): string;
+    getHMAC(format: "B64", options?: {
+        b64Pad?: string;
+    }): string;
+    getHMAC(format: "BYTES"): string;
+    getHMAC(format: "UINT8ARRAY"): Uint8Array;
+    getHMAC(format: "ARRAYBUFFER"): ArrayBuffer;
+    /**
+     * Internal function that returns the "raw" HMAC
+     */
+    protected _getHMAC(): number[];
+}
+
+declare class jsSHA extends jsSHABase<number[], "SHA-1"> {
+    intermediateState: number[];
+    variantBlockSize: number;
+    bigEndianMod: -1 | 1;
+    outputBinLen: number;
+    isVariableLen: boolean;
+    HMACSupported: boolean;
+    converterFunc: (input: any, existingBin: number[], existingBinLen: number) => packedValue;
+    roundFunc: (block: number[], H: number[]) => number[];
+    finalizeFunc: (remainder: number[], remainderBinLen: number, processedBinLen: number, H: number[]) => number[];
+    stateCloneFunc: (state: number[]) => number[];
+    newStateFunc: (variant: "SHA-1") => number[];
+    getMAC: () => number[];
+    constructor(variant: "SHA-1", inputFormat: "TEXT", options?: FixedLengthOptionsEncodingType);
+    constructor(variant: "SHA-1", inputFormat: FormatNoTextType, options?: FixedLengthOptionsNoEncodingType);
+}
+
+export { jsSHA as default };

--- a/dist/sha256.d.mts
+++ b/dist/sha256.d.mts
@@ -1,0 +1,164 @@
+declare type EncodingType = "UTF8" | "UTF16BE" | "UTF16LE";
+declare type FormatNoTextType = "HEX" | "B64" | "BYTES" | "ARRAYBUFFER" | "UINT8ARRAY";
+declare type FormatType = "TEXT" | FormatNoTextType;
+declare type GenericInputType = {
+    value: string;
+    format: "TEXT";
+    encoding?: EncodingType;
+} | {
+    value: string;
+    format: "B64" | "HEX" | "BYTES";
+} | {
+    value: ArrayBuffer;
+    format: "ARRAYBUFFER";
+} | {
+    value: Uint8Array;
+    format: "UINT8ARRAY";
+};
+declare type FixedLengthOptionsNoEncodingType = {
+    hmacKey?: GenericInputType;
+} | {
+    numRounds?: number;
+};
+declare type FixedLengthOptionsEncodingType = {
+    hmacKey?: GenericInputType;
+    encoding?: EncodingType;
+} | {
+    numRounds?: number;
+    encoding?: EncodingType;
+};
+interface packedValue {
+    value: number[];
+    binLen: number;
+}
+
+declare abstract class jsSHABase<StateT, VariantT> {
+    /**
+     * @param variant The desired SHA variant.
+     * @param inputFormat The input format to be used in future `update` calls.
+     * @param options Hashmap of extra input options.
+     */
+    protected readonly shaVariant: VariantT;
+    protected readonly inputFormat: FormatType;
+    protected readonly utfType: EncodingType;
+    protected readonly numRounds: number;
+    protected abstract intermediateState: StateT;
+    protected keyWithIPad: number[];
+    protected keyWithOPad: number[];
+    protected remainder: number[];
+    protected remainderLen: number;
+    protected updateCalled: boolean;
+    protected processedLen: number;
+    protected macKeySet: boolean;
+    protected abstract readonly variantBlockSize: number;
+    protected abstract readonly bigEndianMod: -1 | 1;
+    protected abstract readonly outputBinLen: number;
+    protected abstract readonly isVariableLen: boolean;
+    protected abstract readonly HMACSupported: boolean;
+    protected abstract readonly converterFunc: (input: any, existingBin: number[], existingBinLen: number) => packedValue;
+    protected abstract readonly roundFunc: (block: number[], H: StateT) => StateT;
+    protected abstract readonly finalizeFunc: (remainder: number[], remainderBinLen: number, processedBinLen: number, H: StateT, outputLen: number) => number[];
+    protected abstract readonly stateCloneFunc: (state: StateT) => StateT;
+    protected abstract readonly newStateFunc: (variant: VariantT) => StateT;
+    protected abstract readonly getMAC: ((options: {
+        outputLen: number;
+    }) => number[]) | null;
+    protected constructor(variant: VariantT, inputFormat: "TEXT", options?: FixedLengthOptionsEncodingType);
+    protected constructor(variant: VariantT, inputFormat: FormatNoTextType, options?: FixedLengthOptionsNoEncodingType);
+    /**
+     * Hashes as many blocks as possible.  Stores the rest for either a future update or getHash call.
+     *
+     * @param srcString The input to be hashed.
+     * @returns A reference to the object.
+     */
+    update(srcString: string | ArrayBuffer | Uint8Array): this;
+    /**
+     * Returns the desired SHA hash of the input fed in via `update` calls.
+     *
+     * @param format The desired output formatting
+     * @param options Hashmap of output formatting options. `outputLen` must be specified for variable length hashes.
+     *   `outputLen` replaces the now deprecated `shakeLen` key.
+     * @returns The hash in the format specified.
+     */
+    getHash(format: "HEX", options?: {
+        outputUpper?: boolean;
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "B64", options?: {
+        b64Pad?: string;
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "BYTES", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "UINT8ARRAY", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): Uint8Array;
+    getHash(format: "ARRAYBUFFER", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): ArrayBuffer;
+    /**
+     * Sets the HMAC key for an eventual `getHMAC` call.  Must be called immediately after jsSHA object instantiation.
+     *
+     * @param key The key used to calculate the HMAC
+     * @param inputFormat The format of key.
+     * @param options Hashmap of extra input options.
+     */
+    setHMACKey(key: string, inputFormat: "TEXT", options?: {
+        encoding?: EncodingType;
+    }): void;
+    setHMACKey(key: string, inputFormat: "B64" | "HEX" | "BYTES"): void;
+    setHMACKey(key: ArrayBuffer, inputFormat: "ARRAYBUFFER"): void;
+    setHMACKey(key: Uint8Array, inputFormat: "UINT8ARRAY"): void;
+    /**
+     * Internal function that sets the MAC key.
+     *
+     * @param key The packed MAC key to use
+     */
+    protected _setHMACKey(key: packedValue): void;
+    /**
+     * Returns the the HMAC in the specified format using the key given by a previous `setHMACKey` call.
+     *
+     * @param format The desired output formatting.
+     * @param options Hashmap of extra outputs options.
+     * @returns The HMAC in the format specified.
+     */
+    getHMAC(format: "HEX", options?: {
+        outputUpper?: boolean;
+    }): string;
+    getHMAC(format: "B64", options?: {
+        b64Pad?: string;
+    }): string;
+    getHMAC(format: "BYTES"): string;
+    getHMAC(format: "UINT8ARRAY"): Uint8Array;
+    getHMAC(format: "ARRAYBUFFER"): ArrayBuffer;
+    /**
+     * Internal function that returns the "raw" HMAC
+     */
+    protected _getHMAC(): number[];
+}
+
+declare type VariantType = "SHA-224" | "SHA-256";
+declare class jsSHA extends jsSHABase<number[], VariantType> {
+    intermediateState: number[];
+    variantBlockSize: number;
+    bigEndianMod: -1 | 1;
+    outputBinLen: number;
+    isVariableLen: boolean;
+    HMACSupported: boolean;
+    converterFunc: (input: any, existingBin: number[], existingBinLen: number) => packedValue;
+    roundFunc: (block: number[], H: number[]) => number[];
+    finalizeFunc: (remainder: number[], remainderBinLen: number, processedBinLen: number, H: number[]) => number[];
+    stateCloneFunc: (state: number[]) => number[];
+    newStateFunc: (variant: VariantType) => number[];
+    getMAC: () => number[];
+    constructor(variant: VariantType, inputFormat: "TEXT", options?: FixedLengthOptionsEncodingType);
+    constructor(variant: VariantType, inputFormat: FormatNoTextType, options?: FixedLengthOptionsNoEncodingType);
+}
+
+export { jsSHA as default };

--- a/dist/sha512.d.mts
+++ b/dist/sha512.d.mts
@@ -1,0 +1,177 @@
+declare type EncodingType = "UTF8" | "UTF16BE" | "UTF16LE";
+declare type FormatNoTextType = "HEX" | "B64" | "BYTES" | "ARRAYBUFFER" | "UINT8ARRAY";
+declare type FormatType = "TEXT" | FormatNoTextType;
+declare type GenericInputType = {
+    value: string;
+    format: "TEXT";
+    encoding?: EncodingType;
+} | {
+    value: string;
+    format: "B64" | "HEX" | "BYTES";
+} | {
+    value: ArrayBuffer;
+    format: "ARRAYBUFFER";
+} | {
+    value: Uint8Array;
+    format: "UINT8ARRAY";
+};
+declare type FixedLengthOptionsNoEncodingType = {
+    hmacKey?: GenericInputType;
+} | {
+    numRounds?: number;
+};
+declare type FixedLengthOptionsEncodingType = {
+    hmacKey?: GenericInputType;
+    encoding?: EncodingType;
+} | {
+    numRounds?: number;
+    encoding?: EncodingType;
+};
+interface packedValue {
+    value: number[];
+    binLen: number;
+}
+
+declare abstract class jsSHABase<StateT, VariantT> {
+    /**
+     * @param variant The desired SHA variant.
+     * @param inputFormat The input format to be used in future `update` calls.
+     * @param options Hashmap of extra input options.
+     */
+    protected readonly shaVariant: VariantT;
+    protected readonly inputFormat: FormatType;
+    protected readonly utfType: EncodingType;
+    protected readonly numRounds: number;
+    protected abstract intermediateState: StateT;
+    protected keyWithIPad: number[];
+    protected keyWithOPad: number[];
+    protected remainder: number[];
+    protected remainderLen: number;
+    protected updateCalled: boolean;
+    protected processedLen: number;
+    protected macKeySet: boolean;
+    protected abstract readonly variantBlockSize: number;
+    protected abstract readonly bigEndianMod: -1 | 1;
+    protected abstract readonly outputBinLen: number;
+    protected abstract readonly isVariableLen: boolean;
+    protected abstract readonly HMACSupported: boolean;
+    protected abstract readonly converterFunc: (input: any, existingBin: number[], existingBinLen: number) => packedValue;
+    protected abstract readonly roundFunc: (block: number[], H: StateT) => StateT;
+    protected abstract readonly finalizeFunc: (remainder: number[], remainderBinLen: number, processedBinLen: number, H: StateT, outputLen: number) => number[];
+    protected abstract readonly stateCloneFunc: (state: StateT) => StateT;
+    protected abstract readonly newStateFunc: (variant: VariantT) => StateT;
+    protected abstract readonly getMAC: ((options: {
+        outputLen: number;
+    }) => number[]) | null;
+    protected constructor(variant: VariantT, inputFormat: "TEXT", options?: FixedLengthOptionsEncodingType);
+    protected constructor(variant: VariantT, inputFormat: FormatNoTextType, options?: FixedLengthOptionsNoEncodingType);
+    /**
+     * Hashes as many blocks as possible.  Stores the rest for either a future update or getHash call.
+     *
+     * @param srcString The input to be hashed.
+     * @returns A reference to the object.
+     */
+    update(srcString: string | ArrayBuffer | Uint8Array): this;
+    /**
+     * Returns the desired SHA hash of the input fed in via `update` calls.
+     *
+     * @param format The desired output formatting
+     * @param options Hashmap of output formatting options. `outputLen` must be specified for variable length hashes.
+     *   `outputLen` replaces the now deprecated `shakeLen` key.
+     * @returns The hash in the format specified.
+     */
+    getHash(format: "HEX", options?: {
+        outputUpper?: boolean;
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "B64", options?: {
+        b64Pad?: string;
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "BYTES", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): string;
+    getHash(format: "UINT8ARRAY", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): Uint8Array;
+    getHash(format: "ARRAYBUFFER", options?: {
+        outputLen?: number;
+        shakeLen?: number;
+    }): ArrayBuffer;
+    /**
+     * Sets the HMAC key for an eventual `getHMAC` call.  Must be called immediately after jsSHA object instantiation.
+     *
+     * @param key The key used to calculate the HMAC
+     * @param inputFormat The format of key.
+     * @param options Hashmap of extra input options.
+     */
+    setHMACKey(key: string, inputFormat: "TEXT", options?: {
+        encoding?: EncodingType;
+    }): void;
+    setHMACKey(key: string, inputFormat: "B64" | "HEX" | "BYTES"): void;
+    setHMACKey(key: ArrayBuffer, inputFormat: "ARRAYBUFFER"): void;
+    setHMACKey(key: Uint8Array, inputFormat: "UINT8ARRAY"): void;
+    /**
+     * Internal function that sets the MAC key.
+     *
+     * @param key The packed MAC key to use
+     */
+    protected _setHMACKey(key: packedValue): void;
+    /**
+     * Returns the the HMAC in the specified format using the key given by a previous `setHMACKey` call.
+     *
+     * @param format The desired output formatting.
+     * @param options Hashmap of extra outputs options.
+     * @returns The HMAC in the format specified.
+     */
+    getHMAC(format: "HEX", options?: {
+        outputUpper?: boolean;
+    }): string;
+    getHMAC(format: "B64", options?: {
+        b64Pad?: string;
+    }): string;
+    getHMAC(format: "BYTES"): string;
+    getHMAC(format: "UINT8ARRAY"): Uint8Array;
+    getHMAC(format: "ARRAYBUFFER"): ArrayBuffer;
+    /**
+     * Internal function that returns the "raw" HMAC
+     */
+    protected _getHMAC(): number[];
+}
+
+/**
+ * Int_64 is a object for 2 32-bit numbers emulating a 64-bit number.
+ */
+declare class Int_64 {
+    /**
+     * @param msint_32 The most significant 32-bits of a 64-bit number.
+     * @param lsint_32 The least significant 32-bits of a 64-bit number.
+     */
+    readonly highOrder: number;
+    readonly lowOrder: number;
+    constructor(msint_32: number, lsint_32: number);
+}
+
+declare type VariantType = "SHA-384" | "SHA-512";
+declare class jsSHA extends jsSHABase<Int_64[], VariantType> {
+    intermediateState: Int_64[];
+    variantBlockSize: number;
+    bigEndianMod: -1 | 1;
+    outputBinLen: number;
+    isVariableLen: boolean;
+    HMACSupported: boolean;
+    converterFunc: (input: any, existingBin: number[], existingBinLen: number) => packedValue;
+    roundFunc: (block: number[], H: Int_64[]) => Int_64[];
+    finalizeFunc: (remainder: number[], remainderBinLen: number, processedBinLen: number, H: Int_64[]) => number[];
+    stateCloneFunc: (state: Int_64[]) => Int_64[];
+    newStateFunc: (variant: VariantType) => Int_64[];
+    getMAC: () => number[];
+    constructor(variant: VariantType, inputFormat: "TEXT", options?: FixedLengthOptionsEncodingType);
+    constructor(variant: VariantType, inputFormat: FormatNoTextType, options?: FixedLengthOptionsNoEncodingType);
+}
+
+export { jsSHA as default };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jssha",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jssha",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.5.0",
@@ -33,6 +33,7 @@
         "rollup": "^2.79.1",
         "rollup-plugin-dts": "^4.2.2",
         "rollup-plugin-terser": "^7.0.2",
+        "shelljs": "^0.8.5",
         "sinon": "^12.0.1",
         "ts-node": "^10.9.1",
         "tslib": "^2.4.0",
@@ -3366,6 +3367,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5210,6 +5220,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -6112,6 +6134,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/side-channel": {
@@ -9559,6 +9598,12 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -10945,6 +10990,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -11633,6 +11687,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -120,17 +120,20 @@
     "rollup": "^2.79.1",
     "rollup-plugin-dts": "^4.2.2",
     "rollup-plugin-terser": "^7.0.2",
+    "shelljs": "^0.8.5",
     "sinon": "^12.0.1",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.0",
     "typescript": "^4.8.3"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c;",
+    "postbuild": "npm run emit_esm_types",
     "test": "nyc --reporter=html --reporter=text mocha test/src/*.ts",
     "test_dist": "mocha test/dist/ && karma start karma.conf.js --file-variant sha && karma start karma.conf.js --file-variant sha1 && karma start karma.conf.js --file-variant sha256 && karma start karma.conf.js --file-variant sha512 && karma start karma.conf.js --file-variant sha3",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "emit_esm_types": "node -e \"require('shelljs').find('dist/*.d.ts').forEach(f=>require('fs').copyFileSync(f,f.replace(/\\.ts$/,'.mts')))\";"
   },
   "mocha": {
     "require": [


### PR DESCRIPTION
Fix typescript module resolution issues when `moduleResolution` is set to `node16` or `nodenext` in a `module` `type` package. Some discussions can be found here: https://github.com/pmndrs/zustand/issues/1381#issuecomment-1290296210

Here is a minimal reproduction of this issue: https://stackblitz.com/edit/node-o5zatf?file=src/index.ts
and a patch-fixed version: https://stackblitz.com/edit/node-u9yq9u?file=src/index.ts (the linter is problematic but build result is good)