### PR TITLE
Fix typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -9,7 +9,7 @@ modification, are permitted provided that the following conditions are met:
  * Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- * Neither the name of the the copyright holder nor the names of its
+ * Neither the name of the copyright holder nor the names of its
    contributors may be used to endorse or promote products derived from this
    software without specific prior written permission.
 


### PR DESCRIPTION
Hi!

When adding this project's license to an "OSS licenses" page for some other software, it tripped a markdown typo checker. I know this is a tiny silly patch but it'll fix our markdown linter and appears to me to be a genuine mistake :)

Thanks,
Adam